### PR TITLE
[VT-14] - fix unit test warnings

### DIFF
--- a/src/components/TheSidebarHeader.vue
+++ b/src/components/TheSidebarHeader.vue
@@ -7,8 +7,8 @@
       class="sidebar__header__edit-link"
     >
       <BaseIcon
-        width=40
-        height=40
+        width='40'
+        height='40'
         viewBox='20 -5 76 76'
       >
         <IconPencil></IconPencil>

--- a/src/components/__tests__/CalendarCard.spec.js
+++ b/src/components/__tests__/CalendarCard.spec.js
@@ -3,24 +3,37 @@ import { shallow, createLocalVue } from 'vue-test-utils'
 import CalendarCard from '@/components/CalendarCard'
 import moment from 'moment'
 import VueMomentJS from 'vue-momentjs'
-
-const localVue = createLocalVue()
-localVue.use(Vuex)
-localVue.use(VueMomentJS, moment)
+import { report } from '@/../test/stubs/report'
 
 describe('CalendarCard.vue', () => {
-  const wrapper = shallow(CalendarCard, {
-    localVue,
-    computed: {
-      selectedReport() { return { id: 1 } }
-    },
-    propsData: {
-      report: {
-        id: 1,
-        reportTime: "2018-02-10"
-      }
+  const setup = () => {
+    const getters = {
+      selectedReport: jest.fn()
     }
-  })
+
+    getters.selectedReport.mockReturnValue(report)
+
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+    localVue.use(VueMomentJS, moment)
+
+    const store = new Vuex.Store({
+      state: {},
+      getters
+    })
+
+    const wrapper = shallow(CalendarCard, {
+      localVue,
+      store,
+      propsData: {
+        report
+      }
+    })
+
+    return { wrapper }
+  }
+
+  const { wrapper } = setup()
 
   it('renders correct month', () => {
     expect(wrapper.find('[data-test-calendar-card]').text()).toContain('Feb')

--- a/src/components/__tests__/ReportSelector.spec.js
+++ b/src/components/__tests__/ReportSelector.spec.js
@@ -1,16 +1,42 @@
-import { mount } from 'vue-test-utils'
+import { mount, createLocalVue } from 'vue-test-utils'
 import ReportSelector from '@/components/ReportSelector'
 import CalendarCard from '@/components/CalendarCard'
 import { Carousel, Slide } from 'vue-carousel'
 import { report, secondReport } from '@/../test/stubs/report'
+import Vuex from 'vuex'
+import moment from 'moment'
+import VueMomentJS from 'vue-momentjs'
 
 describe('ReportSelector.vue', () => {
-  const wrapper = mount(ReportSelector, {
-    propsData: {
-      reports: [report, secondReport],
-      fetchingReports: false
+  const setup = () => {
+    const getters = {
+      selectedReport: jest.fn()
     }
-  })
+
+    getters.selectedReport.mockReturnValue(report)
+
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+    localVue.use(VueMomentJS, moment)
+
+    const store = new Vuex.Store({
+      state: {},
+      getters
+    })
+
+    const wrapper = mount(ReportSelector, {
+      localVue,
+      store,
+      propsData: {
+        reports: [report, secondReport],
+        fetchingReports: false
+      }
+    })
+
+    return { wrapper }
+  }
+
+  const { wrapper } = setup()
 
   it('renders Carousel component', () => {
     expect(wrapper.findAll(Carousel)).toHaveLength(1)

--- a/src/components/__tests__/TheHeader.spec.js
+++ b/src/components/__tests__/TheHeader.spec.js
@@ -1,4 +1,4 @@
-import { mount } from 'vue-test-utils'
+import { shallow } from 'vue-test-utils'
 import TheHeader from '@/components/TheHeader.vue'
 import Vuex from 'vuex'
 
@@ -29,7 +29,7 @@ describe('TheHeader.vue', () => {
   test('renders proper header when isAuthenticated', () => {
     getters.isAuthenticated.mockReturnValue(true)
 
-    const wrapper = mount(TheHeader, {
+    const wrapper = shallow(TheHeader, {
       store
     })
 
@@ -40,7 +40,7 @@ describe('TheHeader.vue', () => {
   test('renders proper header when not isAuthenticated', () => {
     getters.isAuthenticated.mockReturnValue(false)
 
-    const wrapper = mount(TheHeader, {
+    const wrapper = shallow(TheHeader, {
       store,
       stubs: ['router-link']
     })
@@ -53,7 +53,7 @@ describe('TheHeader.vue', () => {
     it('onLogout calls logout action', () => {
       getters.isAuthenticated.mockReturnValue(false)
 
-      const wrapper = mount(TheHeader, {
+      const wrapper = shallow(TheHeader, {
         store,
         stubs: ['router-link']
       })

--- a/src/components/__tests__/TheSidebar.spec.js
+++ b/src/components/__tests__/TheSidebar.spec.js
@@ -1,11 +1,15 @@
-import { mount, shallow, createLocalVue } from 'vue-test-utils'
+import { shallow, mount, createLocalVue } from 'vue-test-utils'
 import TheSidebar from '@/components/TheSidebar.vue'
 import TheSidebarHeader from '@/components/TheSidebarHeader.vue'
 import TheSidebarQuickLinks from '@/components/TheSidebarQuickLinks.vue'
 import TheSidebarContent from '@/components/TheSidebarContent.vue'
 import Vuex from 'vuex'
+import moment from 'moment'
+import VueMomentJS from 'vue-momentjs'
 import { report } from '@/../test/stubs/report'
 import { firstVessel, secondVessel } from '@/../test/stubs/vessel'
+import { COMPONENT_NAMES } from '@/constants/vessel-details'
+const { VESSEL_DASHBOARD } = COMPONENT_NAMES
 
 describe('TheSidebar.vue', () => {
   let getters
@@ -15,12 +19,14 @@ describe('TheSidebar.vue', () => {
 
   beforeEach(() => {
     getters = {
+      selectedVesselDetailsComponent: jest.fn(),
       sidebarVisible: jest.fn(),
       vessels: jest.fn()
     }
 
     localVue = createLocalVue()
     localVue.use(Vuex)
+    localVue.use(VueMomentJS, moment)
 
     store = new Vuex.Store({
       state: {},
@@ -37,6 +43,7 @@ describe('TheSidebar.vue', () => {
   })
 
   test('adds sidebar--collapsed when sidebarVisible is false', () => {
+    getters.selectedVesselDetailsComponent.mockReturnValue(VESSEL_DASHBOARD)
     getters.sidebarVisible.mockReturnValue(false)
     getters.vessels.mockReturnValue([firstVessel, secondVessel])
 

--- a/src/components/__tests__/VesselReportsListForm.spec.js
+++ b/src/components/__tests__/VesselReportsListForm.spec.js
@@ -30,6 +30,25 @@ describe('VesselReportsListForm.vue', () => {
         params: {
           id: '1'
         }
+      },
+      $v: {
+        reportData: {
+          reportTime: {
+            $invalid: false
+          },
+          lat: {
+            $invalid: false
+          },
+          lng: {
+            $invalid: false
+          },
+          course: {
+            $invalid: false
+          },
+          spd: {
+            $invalid: false
+          }
+        }
       }
     }
 

--- a/src/components/__tests__/WeatherData.spec.js
+++ b/src/components/__tests__/WeatherData.spec.js
@@ -7,6 +7,15 @@ import WeatherSituation from '@/components/WeatherSituation.vue'
 import WindData from '@/components/WindData.vue'
 import { report } from '@/../test/stubs/report'
 
+Object.defineProperty(document, 'getElementById', {
+  value: jest.fn().mockReturnValue({
+    style: {
+      transform: ''
+    }
+  }
+  ),
+})
+
 const expectedWindData = [
   {
     title: "Wind direction",

--- a/src/pages/__tests__/EditVesselPage.spec.js
+++ b/src/pages/__tests__/EditVesselPage.spec.js
@@ -40,12 +40,32 @@ describe('EditVesselPage.vue', () => {
     }
 
     const router = {
-      push: routerPushSpy
+      push: routerPushSpy,
     }
 
     const mocks = {
       $v: {
-        $invalid: false
+        $invalid: false,
+        vessel: {
+          name: {
+            $invalid: false
+          },
+          imoNumber: {
+            $invalid: false
+          },
+          mmsi: {
+            $invalid: false
+          },
+          gt: {
+            $invalid: false
+          },
+          yob: {
+            $invalid: false
+          },
+          flag: {
+            $invalid: false
+          }
+        }
       }
     }
 

--- a/src/pages/__tests__/MainMenuPage.spec.js
+++ b/src/pages/__tests__/MainMenuPage.spec.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from 'vue-test-utils'
+import { shallow, createLocalVue } from 'vue-test-utils'
 import MainMenuPage from '@/pages/MainMenuPage.vue'
 import TheHeader from '@/components/TheHeader.vue'
 import Vuex from 'vuex'
@@ -19,7 +19,7 @@ describe('MainMenuPage.vue', () => {
       actions
     })
 
-    const wrapper = mount(MainMenuPage, {
+    const wrapper = shallow(MainMenuPage, {
       localVue,
       store,
       stubs: ['router-view']

--- a/src/pages/__tests__/NewVesselPage.spec.js
+++ b/src/pages/__tests__/NewVesselPage.spec.js
@@ -32,7 +32,34 @@ describe('NewVesselPage.vue', () => {
 
     const mocks = {
       $v: {
-        $invalid: false
+        $invalid: false,
+        vessel: {
+          name: {
+            $invalid: false,
+            required: true
+          },
+          imoNumber: {
+            $invalid: false,
+            required: true,
+            numeric: true
+          },
+          mmsi: {
+            $invalid: false,
+            numeric: true
+          },
+          gt: {
+            $invalid: false,
+            numeric: true
+          },
+          yob: {
+            $invalid: false,
+            numeric: true
+          },
+          flag: {
+            $invalid: false,
+            required: true
+          }
+        }
       }
     }
 

--- a/src/pages/__tests__/VesselPage.spec.js
+++ b/src/pages/__tests__/VesselPage.spec.js
@@ -1,13 +1,12 @@
-import { mount, createLocalVue } from 'vue-test-utils'
+import { shallow, createLocalVue } from 'vue-test-utils'
 import VesselPage from '@/pages/VesselPage.vue'
 import TheSidebar from '@/components/TheSidebar.vue'
-import VesselDashboard from '@/components/VesselDashboard.vue'
 import { COMPONENT_NAMES } from '@/constants/vessel-details'
 import Vuex from 'vuex'
 import { firstVessel, secondVessel } from '@/../test/stubs/vessel'
 import { report, secondReport } from '@/../test/stubs/report'
 
-const { VESSEL_DASHBOARD, REPORTS, WEATHER, STATISTICS } = COMPONENT_NAMES
+const { VESSEL_DASHBOARD } = COMPONENT_NAMES
 
 const fetchReportsSpy = jest.fn()
 
@@ -47,7 +46,7 @@ describe('VesselPage.vue', () => {
       }
     }
 
-    const wrapper = mount(VesselPage, {
+    const wrapper = shallow(VesselPage, {
       localVue,
       store,
       mocks

--- a/src/pages/auth/__tests__/SigninPage.spec.js
+++ b/src/pages/auth/__tests__/SigninPage.spec.js
@@ -77,10 +77,6 @@ describe('SigninPage.vue', () => {
     const { wrapper } = setup()
 
     test('with FormWrapper component', () => {
-      var router = wrapper.vm.$router
-      var ref = router.resolve()
-      var location = ref.location
-
       expect(wrapper.findAll(FormWrapper)).toHaveLength(1)
       const formWrapper = wrapper.find(FormWrapper)
       expect(formWrapper.props().title).toEqual('Login')

--- a/src/pages/auth/__tests__/SigninPage.spec.js
+++ b/src/pages/auth/__tests__/SigninPage.spec.js
@@ -10,7 +10,7 @@ const clearAuthErrorSpy = jest.fn()
 const routerPushSpy = jest.fn()
 const routerResolveSpy = jest.fn().mockReturnValue({
   location: {
-    path: {}
+    path: '/fake-path'
   }
 })
 
@@ -36,12 +36,16 @@ describe('SigninPage.vue', () => {
       getters
     })
 
-    const router = {
+    const routerMock = {
       push: routerPushSpy,
       resolve: routerResolveSpy,
       options: {
         linkActiveClass: {}
-      }
+      },
+    }
+
+    const routeMock = {
+      path: '/fake-path'
     }
 
     const mocks = {
@@ -61,7 +65,8 @@ describe('SigninPage.vue', () => {
       store,
       mocks,
       beforeCreate: function () {
-        this._router = router
+        this._router = routerMock
+        this._route = routeMock
       }
     })
 
@@ -72,6 +77,10 @@ describe('SigninPage.vue', () => {
     const { wrapper } = setup()
 
     test('with FormWrapper component', () => {
+      var router = wrapper.vm.$router
+      var ref = router.resolve()
+      var location = ref.location
+
       expect(wrapper.findAll(FormWrapper)).toHaveLength(1)
       const formWrapper = wrapper.find(FormWrapper)
       expect(formWrapper.props().title).toEqual('Login')

--- a/src/pages/auth/__tests__/SigninPage.spec.js
+++ b/src/pages/auth/__tests__/SigninPage.spec.js
@@ -7,6 +7,12 @@ import Vuex from 'vuex'
 
 const loginSpy = jest.fn()
 const clearAuthErrorSpy = jest.fn()
+const routerPushSpy = jest.fn()
+const routerResolveSpy = jest.fn().mockReturnValue({
+  location: {
+    path: {}
+  }
+})
 
 describe('SigninPage.vue', () => {
   const setup = (isFormInvalid = false) => {
@@ -30,16 +36,33 @@ describe('SigninPage.vue', () => {
       getters
     })
 
+    const router = {
+      push: routerPushSpy,
+      resolve: routerResolveSpy,
+      options: {
+        linkActiveClass: {}
+      }
+    }
+
     const mocks = {
       $v: {
-        $invalid: isFormInvalid
+        $invalid: isFormInvalid,
+        email: {
+          $invalid: false
+        },
+        password: {
+          $invalid: false
+        }
       }
     }
 
     const wrapper = mount(SigninPage, {
       localVue,
       store,
-      mocks
+      mocks,
+      beforeCreate: function () {
+        this._router = router
+      }
     })
 
     return { wrapper }

--- a/src/pages/auth/__tests__/SignupPage.spec.js
+++ b/src/pages/auth/__tests__/SignupPage.spec.js
@@ -23,7 +23,21 @@ describe('SignupPage.vue', () => {
 
     const mocks = {
       $v: {
-        $invalid: isFormInvalid
+        $invalid: isFormInvalid,
+        email: {
+          $invalid: false,
+          required: true,
+          email: true
+        },
+        password: {
+          $invalid: false,
+          required: true,
+          minLength: true
+        },
+        confirmPassword: {
+          $invalid: false,
+          sameAs: true
+        }
       }
     }
 


### PR DESCRIPTION
This PR fixes the warnings on unit test suites.

There were few typical reasons for the warnings:
- missing mocks for child components rendered using `mount`
- using `mount` instead of `shallow`
- missing `router` mock
- missing `Vuelidate` validations mocks