### PR TITLE
[VT-18] - add distance to navigation data

### DIFF
--- a/src/components/NavigationData.vue
+++ b/src/components/NavigationData.vue
@@ -12,7 +12,7 @@
         title="Navigation"
         icon="IconNavigation"
         color="blue"
-      ></BaseBadge>
+      />
 
       <div
         slot="body"
@@ -22,7 +22,7 @@
           class="navigation-info__list"
           :items="navigationData"
           size="big"
-        ></BaseList>
+        />
       </div>
     </AccordionWrapper>
   </div>
@@ -49,13 +49,18 @@
       },
       fetchingReports: {
         type: Boolean
+      },
+      distanceMadeSinceLastReport: {
+        type: String
       }
     },
 
     data () {
+      const report = this.report
       return {
-        tweenedCourse: this.report ? this.report.course : 0,
-        tweenedSpd: this.report ? this.report.spd : 0
+        tweenedCourse: report ? report.course : 0,
+        tweenedSpd: report ? report.spd : 0,
+        tweenedDistanceMade: report ? parseInt(this.distanceMadeSinceLastReport) : 0,
       }
     },
 
@@ -64,8 +69,16 @@
         return this.report ? this.report.course : 0
       },
 
+      distanceMade () {
+        return this.report ? this.distanceMadeSinceLastReport : 0
+      },
+
       spd () {
         return this.report ? this.report.spd : 0
+      },
+
+      animatedDistanceMade () {
+        return this.tweenedDistanceMade.toFixed(0)
       },
 
       animatedCourse () {
@@ -84,6 +97,11 @@
           }, {
             title: 'Speed',
             value: this.animatedSpd ? `${this.animatedSpd} kn` : NOT_PROVIDED
+          }, {
+            title: 'Distance made since last report',
+            value: this.animatedDistanceMade ?
+              `${this.animatedDistanceMade} Nm` :
+              NOT_PROVIDED
           }
         ]
       }
@@ -94,8 +112,12 @@
         TweenMax.to(this.$data, 2, { tweenedCourse: newValue })
       },
 
+      distanceMade (newValue) {
+        TweenMax.to(this.$data, 2, { tweenedDistanceMade: newValue })
+      },
+
       spd (newValue) {
-        TweenMax.to(this.$data, 2, { tweenedSpd: newValue })
+        TweenMax.to(this.$data, 2, { tweenedDistanceMade: newValue })
       }
     }
   }

--- a/src/components/NavigationData.vue
+++ b/src/components/NavigationData.vue
@@ -51,7 +51,7 @@
         type: Boolean
       },
       distanceMadeSinceLastReport: {
-        type: String
+        type: Number
       }
     },
 
@@ -60,7 +60,7 @@
       return {
         tweenedCourse: report ? report.course : 0,
         tweenedSpd: report ? report.spd : 0,
-        tweenedDistanceMade: report ? parseInt(this.distanceMadeSinceLastReport) : 0,
+        tweenedDistanceMade: report ? this.distanceMadeSinceLastReport : 0,
       }
     },
 

--- a/src/components/PositionData.vue
+++ b/src/components/PositionData.vue
@@ -12,7 +12,7 @@
         title="Position"
         icon="IconPosition"
         color="red"
-      ></BaseBadge>
+      />
 
       <div
         slot="body"
@@ -22,7 +22,7 @@
           class="position-info__list"
           :items="positionData"
           size="big"
-        ></BaseList>
+        />
       </div>
     </AccordionWrapper>
   </div>

--- a/src/components/VesselDashboard.vue
+++ b/src/components/VesselDashboard.vue
@@ -98,10 +98,10 @@
       },
 
       distanceMadeSinceLastReport () {
-        if (!this.previousReport) return '-'
+        if (!this.previousReport) return false
         const { lat: prevLat, lng: prevLng } = this.previousReport
         const { lat, lng } = this.selectedReport
-        return distanceBetweenPoints(prevLat, prevLng, lat, lng)
+        return parseInt(distanceBetweenPoints(prevLat, prevLng, lat, lng))
       },
 
       reportDate () {

--- a/src/components/VesselDashboard.vue
+++ b/src/components/VesselDashboard.vue
@@ -34,6 +34,7 @@
           class="vessel-dashboard__row__item"
           :report="selectedReport"
           :fetchingReports="fetchingReports"
+          :distanceMadeSinceLastReport="distanceMadeSinceLastReport"
         />
       </div>
     </div>
@@ -63,6 +64,7 @@
   import NavigationData from './NavigationData.vue'
   import RemainingOnBoard from './RemainingOnBoard.vue'
   import ReportSelector from './ReportSelector'
+  import { distanceBetweenPoints } from '@/utils/coordinates-utils'
 
   export default {
     components: {
@@ -93,6 +95,13 @@
       previousReport () {
         const indexOfSelectedReport = this.reports.indexOf(this.selectedReport)
         return this.reports[indexOfSelectedReport + 1]
+      },
+
+      distanceMadeSinceLastReport () {
+        if (!this.previousReport) return '-'
+        const { lat: prevLat, lng: prevLng } = this.previousReport
+        const { lat, lng } = this.selectedReport
+        return distanceBetweenPoints(prevLat, prevLng, lat, lng)
       },
 
       reportDate () {

--- a/src/components/VesselReportsListItemDetails.vue
+++ b/src/components/VesselReportsListItemDetails.vue
@@ -104,7 +104,7 @@
         reportChangeset: {
           ...this.report,
           lat: stripSymbols(decimalToDMS(this.report.lat)),
-          lng: stripSymbols(decimalToDMS(this.report.lng, true))
+          lng: stripSymbols(decimalToDMS(this.report.lng, false))
         }
       }
     },
@@ -119,7 +119,7 @@
         this.reportChangeset = {
           ...this.report,
           lat: stripSymbols(decimalToDMS(this.report.lat)),
-          lng: stripSymbols(decimalToDMS(this.report.lng, true))
+          lng: stripSymbols(decimalToDMS(this.report.lng, false))
         }
       },
 

--- a/src/components/__tests__/NavigationData.spec.js
+++ b/src/components/__tests__/NavigationData.spec.js
@@ -8,7 +8,8 @@ describe('NavigationData.vue', () => {
   const wrapper = mount(NavigationData, {
     propsData: {
       report,
-      fetchingReports: false
+      fetchingReports: false,
+      distanceMadeSinceLastReport: 120
     }
   })
 
@@ -18,5 +19,21 @@ describe('NavigationData.vue', () => {
 
   it('renders BaseList component', () => {
     expect(wrapper.findAll(BaseList)).toHaveLength(1)
+  })
+
+  it('renders proper number of items', () => {
+    expect(wrapper.findAll('[data-test-base-list-item]')).toHaveLength(3)
+  })
+
+  it('contains Course item', () => {
+    expect(wrapper.text()).toContain('90°')
+  })
+
+  it('contains Speed item', () => {
+    expect(wrapper.text()).toContain('12 kn')
+  })
+
+  it('contains Distance made since last report value', () => {
+    expect(wrapper.text()).toContain('120 Nm')
   })
 })

--- a/src/components/__tests__/NavigationData.spec.js
+++ b/src/components/__tests__/NavigationData.spec.js
@@ -26,14 +26,14 @@ describe('NavigationData.vue', () => {
   })
 
   it('contains Course item', () => {
-    expect(wrapper.text()).toContain('90°')
+    expect(wrapper.text()).toContain(`${wrapper.vm.report.course}°`)
   })
 
   it('contains Speed item', () => {
-    expect(wrapper.text()).toContain('12 kn')
+    expect(wrapper.text()).toContain(`${wrapper.vm.report.spd} kn`)
   })
 
   it('contains Distance made since last report value', () => {
-    expect(wrapper.text()).toContain('120 Nm')
+    expect(wrapper.text()).toContain(`${wrapper.vm.distanceMadeSinceLastReport} Nm`)
   })
 })

--- a/src/components/__tests__/VesselDashboard.spec.js
+++ b/src/components/__tests__/VesselDashboard.spec.js
@@ -89,5 +89,18 @@ describe('VesselDashboard.vue', () => {
       const { wrapper } = setup()
       expect(wrapper.vm.previousReport).toEqual(report)
     })
+
+    describe('distanceMadeSinceLastReport returns proper value', () => {
+      const { wrapper } = setup()
+
+      it('returns properly calculated distance when previuosReport exist', () => {
+        expect(wrapper.vm.distanceMadeSinceLastReport).toEqual(1447)
+      })
+
+      it('returns early when previuosReport does not exist', () => {
+        wrapper.setComputed({ previousReport: undefined })
+        expect(wrapper.vm.distanceMadeSinceLastReport).toEqual(false)
+      })
+    })
   })
 })

--- a/src/components/__tests__/VesselReportsListItemDetails.spec.js
+++ b/src/components/__tests__/VesselReportsListItemDetails.spec.js
@@ -156,7 +156,7 @@ describe('VesselReportsListItemDetails.vue', () => {
         fwRob: 80,
         id: '-L7yuO7nLZtMgEe8qth6',
         lat: '12 20.3 N',
-        lng: '12 20.4 N',
+        lng: '012 20.4 E',
         pitch: 1,
         pob: 67,
         reportTime: '2018-02-10',

--- a/src/utils/coordinates-utils.js
+++ b/src/utils/coordinates-utils.js
@@ -31,10 +31,10 @@ function decimalToDMS (decimal, latitude = true, degrees = 0, minutes = 0, secon
 
 function distanceBetweenPoints (depLat, depLng, arrLat, arrLng) {
   const R = 6371e3
-  const lat1 = depLat.toRadians()
-  const lat2 = arrLat.toRadians()
-  const dlat = (arrLat - depLat).toRadians()
-  const dlng = (arrLng - depLng).toRadians()
+  const lat1 = toRadians(depLat)
+  const lat2 = toRadians(arrLat)
+  const dlat = toRadians(arrLat - depLat)
+  const dlng = toRadians(arrLng - depLng)
 
   const a = Math.sin(dlat / 2) * Math.sin(dlat / 2) +
     Math.cos(lat1) * Math.cos(lat2) *
@@ -42,7 +42,7 @@ function distanceBetweenPoints (depLat, depLng, arrLat, arrLng) {
 
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
 
-  return R * c
+  return (R * c / 1852).toFixed(0)
 }
 
 function formatLatForPersistanceLayer (lat) {
@@ -65,6 +65,10 @@ function formatLngForPersistanceLayer (lng) {
 
 function stripSymbols (coordinate) {
   return coordinate.replace(String.fromCharCode(176), '').replace("'", '')
+}
+
+function toRadians (value) {
+  return value * Math.PI / 180
 }
 
 export { decimalToDMS, distanceBetweenPoints, formatLatForPersistanceLayer, formatLngForPersistanceLayer, stripSymbols }


### PR DESCRIPTION
This PR add additional data to `Navigation Data` component about distance made by the vessel since last report.

<img width="518" alt="screen shot 2018-06-10 at 16 35 46" src="https://user-images.githubusercontent.com/17565389/41202635-605bc1fa-6ccc-11e8-8912-7e3910ae90f3.png">
